### PR TITLE
Rework the history importers to reduce the number of rejected rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,7 @@ NOTE: output changed to the new MTransaction from the deprecated MHistory.
 Output schema: 
 * [openalloc/transaction](https://github.com/openalloc/AllocData#mtransaction)
 
-### Chuck (Schwab) Positions **BETA**
-
-_This is an early release, and probably has bugs._
+### Chuck (Schwab) Positions
 
 There are actually two importers to handle Schwab positions. One for 'All' accounts, and a second for 'Individual' accounts. The files are named differently:
 
@@ -119,9 +117,7 @@ Output schemas:
 * [openalloc/security](https://github.com/openalloc/AllocData#msecurity)
 * [openalloc/meta/source](https://github.com/openalloc/AllocData#msourcemeta)
 
-### Chuck (Schwab) Transaction History **BETA**
-
-_This is an early release, and probably has bugs._
+### Chuck (Schwab) Transaction History
 
 To transform the "XXXX1234_Transactions_YYYYMMDD-HHMMSS.CSV" export, which contains a record of recent sales, purchases, and other transactions:
 
@@ -131,9 +127,11 @@ $ finport transform XXXX1234_Transactions_YYYYMMDD-HHMMSS.CSV
 
 The command above will produce comma-separated value data in the following schema.
 
-NOTE: Schwab's transaction export does not contain realized gains and losses of sales, and so they are not in the imported transaction.
-
 Output schema:  [openalloc/transaction](https://github.com/openalloc/AllocData#mtransaction)
+
+NOTE 1: Schwab's transaction export does not contain realized gains and losses of sales, and so they are not in the imported transaction.
+
+NOTE 2: Security transfers may only specify shares transferred, with no cash valuation specified.
 
 ### Chuck (Schwab) Transaction Sales **BETA**
 

--- a/Sources/Helpers/ChuckPositions.swift
+++ b/Sources/Helpers/ChuckPositions.swift
@@ -108,13 +108,12 @@ struct ChuckPositions {
         return decodedRow
     }
     
-    static func parseBlock<T: AllocRowed>(_ type: T.Type,
-                                          block: String,
-                                          outputSchema: AllocSchema,
-                                          rejectedRows: inout [AllocRowed.RawRow],
-                                          timestamp: Date?,
-                                          accountTitleRE: String,
-                                          csvRE: String) throws -> [T.DecodedRow] {
+    static func parseBlock(block: String,
+                           outputSchema: AllocSchema,
+                           rejectedRows: inout [AllocRowed.RawRow],
+                           timestamp: Date?,
+                           accountTitleRE: String,
+                           csvRE: String) throws -> [AllocRowed.DecodedRow] {
         
         // first line has the account ID & title
         let tuple: (id: String, title: String)? = {

--- a/Sources/Helpers/ChuckPositions.swift
+++ b/Sources/Helpers/ChuckPositions.swift
@@ -138,7 +138,7 @@ struct ChuckPositions {
     }
     
     static func parseBlock<T: AllocRowed>(_ type: T.Type,
-                                          str: String,
+                                          block: String,
                                           outputSchema: AllocSchema,
                                           rejectedRows: inout [[String : String]],
                                           timestamp: Date?,
@@ -147,8 +147,8 @@ struct ChuckPositions {
         
         // first line has the account ID & title
         let tuple: (id: String, title: String)? = {
-            let _range = str.lineRange(for: ..<str.startIndex)
-            let rawStr = str[_range].trimmingCharacters(in: .whitespacesAndNewlines)
+            let _range = block.lineRange(for: ..<block.startIndex)
+            let rawStr = block[_range].trimmingCharacters(in: .whitespacesAndNewlines)
             return parseAccountTitleID(accountTitleRE, rawStr)
         }()
         
@@ -160,9 +160,9 @@ struct ChuckPositions {
                     MAccount.CodingKeys.title.rawValue: accountTitle
                 ]]
                 
-            } else if let csvRange = str.range(of: csvRE,
+            } else if let csvRange = block.range(of: csvRE,
                                                options: .regularExpression) {
-                let csvStr = str[csvRange]
+                let csvStr = block[csvRange]
                 let delimitedRows = try CSV(string: String(csvStr)).namedRows
                 return decodeDelimitedRows(delimitedRows: delimitedRows,
                                                   outputSchema_: outputSchema,

--- a/Sources/Helpers/ChuckPositions.swift
+++ b/Sources/Helpers/ChuckPositions.swift
@@ -105,7 +105,7 @@ struct ChuckPositions {
         return decodedRow
     }
     
-    /// obtain the ticker, ignoring row if blank/missing (or if "Account Total")
+    /// obtain the ticker, ignoring (but not rejecting) row if blank/missing (or if "Account Total")
     internal static func getRawSymbol(_ row: AllocRowed.RawRow) -> String? {
         guard let rawSymbol = MHolding.parseString(row["Symbol"], trimCharacters: trimFromTicker),
               rawSymbol.count > 0,

--- a/Sources/Helpers/ChuckPositions.swift
+++ b/Sources/Helpers/ChuckPositions.swift
@@ -145,8 +145,6 @@ struct ChuckPositions {
                                           accountTitleRE: String,
                                           csvRE: String) throws -> [T.DecodedRow] {
         
-        var items = [T.DecodedRow]()
-        
         // first line has the account ID & title
         let tuple: (id: String, title: String)? = {
             let _range = str.lineRange(for: ..<str.startIndex)
@@ -157,24 +155,23 @@ struct ChuckPositions {
         if let (accountID, accountTitle) = tuple {
             
             if outputSchema == .allocAccount {
-                items.append([
+                return [[
                     MAccount.CodingKeys.accountID.rawValue: accountID,
                     MAccount.CodingKeys.title.rawValue: accountTitle
-                ])
+                ]]
                 
             } else if let csvRange = str.range(of: csvRE,
                                                options: .regularExpression) {
                 let csvStr = str[csvRange]
                 let delimitedRows = try CSV(string: String(csvStr)).namedRows
-                let nuItems = decodeDelimitedRows(delimitedRows: delimitedRows,
+                return decodeDelimitedRows(delimitedRows: delimitedRows,
                                                   outputSchema_: outputSchema,
                                                   accountID: accountID,
                                                   rejectedRows: &rejectedRows,
                                                   timestamp: timestamp)
-                items.append(contentsOf: nuItems)
             }
         }
         
-        return items
+        return []
     }
 }

--- a/Sources/Helpers/ChuckPositions.swift
+++ b/Sources/Helpers/ChuckPositions.swift
@@ -137,13 +137,15 @@ struct ChuckPositions {
         return (captured[1], captured[0])
     }
     
-    static func parseBlock(str: String,
-                            outputSchema: AllocSchema,
-                            items: inout [[String : AnyHashable]],
-                            rejectedRows: inout [[String : String]],
-                            timestamp: Date?,
-                            accountTitleRE: String,
-                            csvRE: String) throws {
+    static func parseBlock<T: AllocRowed>(_ type: T.Type,
+                                          str: String,
+                                          outputSchema: AllocSchema,
+                                          rejectedRows: inout [[String : String]],
+                                          timestamp: Date?,
+                                          accountTitleRE: String,
+                                          csvRE: String) throws -> [T.DecodedRow] {
+        
+        var items = [T.DecodedRow]()
         
         // first line has the account ID & title
         let tuple: (id: String, title: String)? = {
@@ -165,12 +167,14 @@ struct ChuckPositions {
                 let csvStr = str[csvRange]
                 let delimitedRows = try CSV(string: String(csvStr)).namedRows
                 let nuItems = decodeDelimitedRows(delimitedRows: delimitedRows,
-                                                                 outputSchema_: outputSchema,
-                                                                 accountID: accountID,
-                                                                 rejectedRows: &rejectedRows,
-                                                                 timestamp: timestamp)
+                                                  outputSchema_: outputSchema,
+                                                  accountID: accountID,
+                                                  rejectedRows: &rejectedRows,
+                                                  timestamp: timestamp)
                 items.append(contentsOf: nuItems)
             }
         }
+        
+        return items
     }
 }

--- a/Sources/Importers/ChuckHistory.swift
+++ b/Sources/Importers/ChuckHistory.swift
@@ -205,7 +205,10 @@ class ChuckHistory: FINporter {
             } else {
                 guard let quantity = rawQuantity else { return nil }
                 decodedRow[MTransaction.CodingKeys.shareCount.rawValue] = quantity
-                decodedRow[MTransaction.CodingKeys.securityID.rawValue] = rawSymbol
+                
+                if let symbol = rawSymbol {
+                    decodedRow[MTransaction.CodingKeys.securityID.rawValue] = symbol
+                }
                 
                 // amount may be nil on "Security Transfer", in which case we'll omit sharePrice
                 if let amount = rawAmount {

--- a/Sources/Importers/ChuckHistory.swift
+++ b/Sources/Importers/ChuckHistory.swift
@@ -149,7 +149,7 @@ class ChuckHistory: FINporter {
         
         let netAction: MTransaction.Action = {
             switch rawAction {
-            case "Buy":
+            case "Buy", "Reinvest Shares":
                 return .buysell
             case "Sell":
                 isSale = true

--- a/Sources/Importers/ChuckHistory.swift
+++ b/Sources/Importers/ChuckHistory.swift
@@ -156,7 +156,7 @@ class ChuckHistory: FINporter {
                 return .buysell
             case "Security Transfer":
                 return .transfer
-            case "Cash Dividend", "Bank Interest", "Promotional Award":
+            case "Reinvest Dividend", "Cash Dividend", "Bank Interest", "Promotional Award":
                 return .income
             default:
                 return .miscflow

--- a/Sources/Importers/ChuckPositionsAll.swift
+++ b/Sources/Importers/ChuckPositionsAll.swift
@@ -95,8 +95,7 @@ class ChuckPositionsAll: FINporter {
         // one block per account expected
         while let range = str.range(of: ChuckPositionsAll.accountBlockRE,
                                     options: .regularExpression) {
-            let nuItems = try ChuckPositions.parseBlock(type,
-                                                        block: String(str[range]),
+            let nuItems = try ChuckPositions.parseBlock(block: String(str[range]),
                                                         outputSchema: outputSchema_,
                                                         
                                                         rejectedRows: &rejectedRows,

--- a/Sources/Importers/ChuckPositionsAll.swift
+++ b/Sources/Importers/ChuckPositionsAll.swift
@@ -95,10 +95,8 @@ class ChuckPositionsAll: FINporter {
         // one block per account expected
         while let range = str.range(of: ChuckPositionsAll.accountBlockRE,
                                     options: .regularExpression) {
-            let block = str[range]
-            
             let nuItems = try ChuckPositions.parseBlock(type,
-                                                        block: String(block),
+                                                        block: String(str[range]),
                                                         outputSchema: outputSchema_,
                                                         
                                                         rejectedRows: &rejectedRows,

--- a/Sources/Importers/ChuckPositionsAll.swift
+++ b/Sources/Importers/ChuckPositionsAll.swift
@@ -53,7 +53,7 @@ class ChuckPositionsAll: FINporter {
     """#
     
     internal static let accountTitleRE = #""(.+?)\s+([A-Z0-9-_]+)""# // lazy greedy non-space
-
+    
     override func detect(dataPrefix: Data) throws -> DetectResult {
         guard let str = FINporter.normalizeDecode(dataPrefix),
               str.range(of: ChuckPositionsAll.headerRE,
@@ -68,14 +68,14 @@ class ChuckPositionsAll: FINporter {
     }
     
     override open func decode<T: AllocRowed>(_ type: T.Type,
-                                            _ data: Data,
-                                            rejectedRows: inout [T.RawRow],
-                                            inputFormat _: AllocFormat? = nil,
-                                            outputSchema: AllocSchema? = nil,
-                                            url: URL? = nil,
-                                            defTimeOfDay _: String? = nil,
-                                            timeZone _: TimeZone = TimeZone.current,
-                                            timestamp: Date? = nil) throws -> [T.DecodedRow] {
+                                             _ data: Data,
+                                             rejectedRows: inout [T.RawRow],
+                                             inputFormat _: AllocFormat? = nil,
+                                             outputSchema: AllocSchema? = nil,
+                                             url: URL? = nil,
+                                             defTimeOfDay _: String? = nil,
+                                             timeZone _: TimeZone = TimeZone.current,
+                                             timestamp: Date? = nil) throws -> [T.DecodedRow] {
         guard var str = FINporter.normalizeDecode(data) else {
             throw FINporterError.decodingError("unable to parse data")
         }
@@ -97,33 +97,13 @@ class ChuckPositionsAll: FINporter {
                                     options: .regularExpression) {
             let block = str[range]
             
-            // first line has the account ID & title
-            let tuple: (id: String, title: String)? = {
-                let _range = block.lineRange(for: ..<block.startIndex)
-                let rawStr = block[_range].trimmingCharacters(in: .whitespacesAndNewlines)
-                return ChuckPositions.parseAccountTitleID(ChuckPositionsAll.accountTitleRE, rawStr)
-            }()
-            
-            if let (accountID, accountTitle) = tuple {
-                
-                if outputSchema_ == .allocAccount {
-                    items.append([
-                        MAccount.CodingKeys.accountID.rawValue: accountID,
-                        MAccount.CodingKeys.title.rawValue: accountTitle
-                    ])
-                    
-                } else if let csvRange = block.range(of: ChuckPositionsAll.csvRE,
-                                                     options: .regularExpression) {
-                    let csvStr = block[csvRange]
-                    let delimitedRows = try CSV(string: String(csvStr)).namedRows
-                    let nuItems = ChuckPositions.decodeDelimitedRows(delimitedRows: delimitedRows,
-                                                                     outputSchema_: outputSchema_,
-                                                                     accountID: accountID,
-                                                                     rejectedRows: &rejectedRows,
-                                                                     timestamp: timestamp)
-                    items.append(contentsOf: nuItems)
-                }
-            }
+            try ChuckPositions.parseBlock(str: String(block),
+                                          outputSchema: outputSchema_,
+                                          items: &items,
+                                          rejectedRows: &rejectedRows,
+                                          timestamp: timestamp,
+                                          accountTitleRE: ChuckPositionsAll.accountTitleRE,
+                                          csvRE: ChuckPositionsAll.csvRE)
             
             str.removeSubrange(range) // discard blocks as they are consumed
         }

--- a/Sources/Importers/ChuckPositionsAll.swift
+++ b/Sources/Importers/ChuckPositionsAll.swift
@@ -97,13 +97,16 @@ class ChuckPositionsAll: FINporter {
                                     options: .regularExpression) {
             let block = str[range]
             
-            try ChuckPositions.parseBlock(str: String(block),
-                                          outputSchema: outputSchema_,
-                                          items: &items,
-                                          rejectedRows: &rejectedRows,
-                                          timestamp: timestamp,
-                                          accountTitleRE: ChuckPositionsAll.accountTitleRE,
-                                          csvRE: ChuckPositionsAll.csvRE)
+            let nuItems = try ChuckPositions.parseBlock(type,
+                                                        str: String(block),
+                                                        outputSchema: outputSchema_,
+                                                        
+                                                        rejectedRows: &rejectedRows,
+                                                        timestamp: timestamp,
+                                                        accountTitleRE: ChuckPositionsAll.accountTitleRE,
+                                                        csvRE: ChuckPositionsAll.csvRE)
+            
+            items.append(contentsOf: nuItems)
             
             str.removeSubrange(range) // discard blocks as they are consumed
         }

--- a/Sources/Importers/ChuckPositionsAll.swift
+++ b/Sources/Importers/ChuckPositionsAll.swift
@@ -98,7 +98,7 @@ class ChuckPositionsAll: FINporter {
             let block = str[range]
             
             let nuItems = try ChuckPositions.parseBlock(type,
-                                                        str: String(block),
+                                                        block: String(block),
                                                         outputSchema: outputSchema_,
                                                         
                                                         rejectedRows: &rejectedRows,

--- a/Sources/Importers/ChuckPositionsIndiv.swift
+++ b/Sources/Importers/ChuckPositionsIndiv.swift
@@ -83,8 +83,7 @@ class ChuckPositionsIndiv: FINporter {
             return [item]
         }
         
-        return try ChuckPositions.parseBlock(type,
-                                             block: str,
+        return try ChuckPositions.parseBlock(block: str,
                                              outputSchema: outputSchema_,
                                              rejectedRows: &rejectedRows,
                                              timestamp: timestamp,

--- a/Sources/Importers/ChuckPositionsIndiv.swift
+++ b/Sources/Importers/ChuckPositionsIndiv.swift
@@ -84,7 +84,7 @@ class ChuckPositionsIndiv: FINporter {
         }
         
         return try ChuckPositions.parseBlock(type,
-                                             str: str,
+                                             block: str,
                                              outputSchema: outputSchema_,
                                              rejectedRows: &rejectedRows,
                                              timestamp: timestamp,

--- a/Sources/Importers/ChuckPositionsIndiv.swift
+++ b/Sources/Importers/ChuckPositionsIndiv.swift
@@ -90,8 +90,4 @@ class ChuckPositionsIndiv: FINporter {
                                              accountTitleRE: ChuckPositionsIndiv.accountTitleRE,
                                              csvRE: ChuckPositionsIndiv.csvRE)
     }
-    
-    
-    
-    
 }

--- a/Sources/Importers/ChuckPositionsIndiv.swift
+++ b/Sources/Importers/ChuckPositionsIndiv.swift
@@ -78,23 +78,18 @@ class ChuckPositionsIndiv: FINporter {
             throw FINporterError.needExplicitOutputSchema(outputSchemas)
         }
         
-        var items = [T.DecodedRow]()
-        
         if outputSchema_ == .allocMetaSource {
             let item = ChuckPositions.meta(self.id, str, url)
-            items.append(item)
-            return items
+            return [item]
         }
         
-        try ChuckPositions.parseBlock(str: str,
-                                      outputSchema: outputSchema_,
-                                      items: &items,
-                                      rejectedRows: &rejectedRows,
-                                      timestamp: timestamp,
-                                      accountTitleRE: ChuckPositionsIndiv.accountTitleRE,
-                                      csvRE: ChuckPositionsIndiv.csvRE)
-        
-        return items
+        return try ChuckPositions.parseBlock(type,
+                                             str: str,
+                                             outputSchema: outputSchema_,
+                                             rejectedRows: &rejectedRows,
+                                             timestamp: timestamp,
+                                             accountTitleRE: ChuckPositionsIndiv.accountTitleRE,
+                                             csvRE: ChuckPositionsIndiv.csvRE)
     }
     
     

--- a/Sources/Importers/FidoHistory.swift
+++ b/Sources/Importers/FidoHistory.swift
@@ -133,6 +133,8 @@ class FidoHistory: FINporter {
                 return .buysell
             case let str where str.starts(with: "REDEMPTION FROM "):
                 return .buysell
+//            case let str where str.starts(with: "REINVEST SHARES "):
+//                return .buysell
             case let str where str.starts(with: "TRANSFER OF ASSETS "):
                 return .transfer
             case let str where str.starts(with: "DIVIDEND RECEIVED "):

--- a/Sources/Importers/FidoHistory.swift
+++ b/Sources/Importers/FidoHistory.swift
@@ -95,7 +95,6 @@ class FidoHistory: FINporter {
                   let rawDate = delimitedRow["Run Date"],
                   let transactedAt = parseFidoMMDDYYYY(rawDate, defTimeOfDay: defTimeOfDay, timeZone: timeZone),
                   let accountNameNumber = MTransaction.parseString(delimitedRow["Account"]),
-                  let amount = MTransaction.parseDouble(delimitedRow["Amount ($)"]),
                   let accountID = accountNameNumber.split(separator: " ").last,
                   accountID.count > 0
             else {
@@ -106,7 +105,6 @@ class FidoHistory: FINporter {
             guard let decodedRow = decodeRow(delimitedRow: delimitedRow,
                                              transactedAt: transactedAt,
                                              rawAction: rawAction,
-                                             amount: amount,
                                              accountID: String(accountID))
             else {
                 rejectedRows.append(delimitedRow)
@@ -120,7 +118,6 @@ class FidoHistory: FINporter {
     internal func decodeRow(delimitedRow: AllocRowed.RawRow,
                             transactedAt: Date,
                             rawAction: String,
-                            amount: Double,
                             accountID: String) -> AllocRowed.DecodedRow? {
         
         let netAction: MTransaction.Action = {
@@ -156,11 +153,16 @@ class FidoHistory: FINporter {
             MTransaction.CodingKeys.accountID.rawValue: accountID,
         ]
 
+        let rawAmount = MTransaction.parseDouble(delimitedRow["Amount ($)"])
+        let rawSymbol = MTransaction.parseString(delimitedRow["Symbol"])
+        let rawShareCount = MTransaction.parseDouble(delimitedRow["Quantity"])
+        let rawSharePrice = MTransaction.parseDouble(delimitedRow["Price ($)"])
+        
         switch netAction {
         case .buysell:
-            guard let symbol = MTransaction.parseString(delimitedRow["Symbol"]),
-                  let shareCount = MTransaction.parseDouble(delimitedRow["Quantity"]),
-                  let sharePrice = MTransaction.parseDouble(delimitedRow["Price ($)"])
+            guard let symbol = rawSymbol,
+                  let shareCount = rawShareCount,
+                  let sharePrice = rawSharePrice
             else {
                 return nil
             }
@@ -170,27 +172,33 @@ class FidoHistory: FINporter {
             decodedRow[MTransaction.CodingKeys.sharePrice.rawValue] = sharePrice
             
         case .transfer:
-            if let symbol = MTransaction.parseString(delimitedRow["Symbol"]) {
-                guard let quantity = MTransaction.parseDouble(delimitedRow["Quantity"]),
-                      let sharePrice = MTransaction.parseDouble(delimitedRow["Price ($)"])
+            if let symbol = rawSymbol {
+                guard let quantity = rawShareCount,
+                      let sharePrice = rawSharePrice
                 else {
                     return nil
                 }
+                
                 decodedRow[MTransaction.CodingKeys.shareCount.rawValue] = quantity
                 decodedRow[MTransaction.CodingKeys.sharePrice.rawValue] = sharePrice
                 decodedRow[MTransaction.CodingKeys.securityID.rawValue] = symbol
             } else {
-                // it's probably cash
+                // no symbol, so it's probably cash
+                guard let amount = rawAmount else { return nil }
+                
                 decodedRow[MTransaction.CodingKeys.shareCount.rawValue] = amount
                 decodedRow[MTransaction.CodingKeys.sharePrice.rawValue] = 1.0
-                decodedRow[MTransaction.CodingKeys.securityID.rawValue] = ""
             }
 
         case .income, .miscflow:
-            let symbol = MTransaction.parseString(delimitedRow["Symbol"])
+            guard let amount = rawAmount else { return nil }
+            
             decodedRow[MTransaction.CodingKeys.shareCount.rawValue] = amount
             decodedRow[MTransaction.CodingKeys.sharePrice.rawValue] = 1.0
-            decodedRow[MTransaction.CodingKeys.securityID.rawValue] = symbol
+            
+            if let symbol = rawSymbol {
+                decodedRow[MTransaction.CodingKeys.securityID.rawValue] = symbol
+            }
         }
         
         return decodedRow

--- a/Sources/Importers/FidoHistory.swift
+++ b/Sources/Importers/FidoHistory.swift
@@ -133,8 +133,8 @@ class FidoHistory: FINporter {
                 return .buysell
             case let str where str.starts(with: "REDEMPTION FROM "):
                 return .buysell
-//            case let str where str.starts(with: "REINVEST SHARES "):
-//                return .buysell
+            case let str where str.starts(with: "REINVESTMENT "):
+                return .buysell
             case let str where str.starts(with: "TRANSFER OF ASSETS "):
                 return .transfer
             case let str where str.starts(with: "DIVIDEND RECEIVED "):

--- a/Sources/Importers/FidoHistory.swift
+++ b/Sources/Importers/FidoHistory.swift
@@ -137,6 +137,10 @@ class FidoHistory: FINporter {
                 return .transfer
             case let str where str.starts(with: "DIVIDEND RECEIVED "):
                 return .income
+            case let str where str.starts(with: "LONG-TERM CAP GAIN "):
+                return .income
+            case let str where str.starts(with: "SHORT-TERM CAP GAIN "):
+                return .income
             case let str where str.starts(with: "INTEREST EARNED "):
                 return .income
             default:

--- a/Tests/Importers/ChuckHistoryActionTests.swift
+++ b/Tests/Importers/ChuckHistoryActionTests.swift
@@ -206,61 +206,73 @@ final class ChuckHistoryActionTests: XCTestCase {
         let accountID = "XXXX-5678"
         
         let rows: [(String, AllocRowed.DecodedRow)] = [
+
             (
             """
             "03/01/2021","MoneyLink Transfer","","My Bank","","","","-$17.00",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
+
             (
             """
             "03/01/2021","Sell","VOO","VANGUARD S&P 500","10","$17.00","$0.04","$170.12",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": -10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
+
             (
             """
             "03/01/2021","Buy","VOO","VANGUARD S&P 500","10","$17.0","","-$1370.12",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
-            ( //TODO what should reinvest be?
+
+            (
+            """
+            "03/01/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]), //, "txnSecurityID": "VOO"
+
+            (
             """
             "03/01/2021","Reinvest Shares","VOO","VANGUARD S&P 500","0.10","$17.00","","-$3.71",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 0.1, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
-            ( //TODO what to do?
-            """
-            "03/01/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
-            """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]), //, "txnSecurityID": "VOO"
+
             (
             """
             "03/01/2021","Cash Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
+            
             ( //TODO broken
             """
             "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","-50","","","",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -50.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
+            
             ( //TODO broken
             """
             "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","200","","","",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
+
             (
             """
             "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","$200.00",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""]),
+
             (
             """
             "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","-$200.00",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""]),
+
             (
             """
             "03/01/2021","Promotional Award","","PROMOTIONAL AWARD","","","","$100.00",
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
+
             (
             """
             "03/01/2021 as of 09/26/2021","Bank Interest","","BANK INT 123456-789123 SCHWAB BANK","","","","$17.00",

--- a/Tests/Importers/ChuckHistoryActionTests.swift
+++ b/Tests/Importers/ChuckHistoryActionTests.swift
@@ -207,12 +207,8 @@ final class ChuckHistoryActionTests: XCTestCase {
         
         let rows: [(csvRow: String, expected: AllocRowed.DecodedRow)] = [
 
-            (
-            """
-            "03/01/2021","MoneyLink Transfer","","My Bank","","","","-$17.00",
-            """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
-
+            // buysell
+            
             (
             """
             "03/01/2021","Sell","VOO","VANGUARD S&P 500","10","$17.00","$0.04","$170.12",
@@ -231,6 +227,9 @@ final class ChuckHistoryActionTests: XCTestCase {
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 0.1, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
 
+
+            // transfer
+            
             // with OUTGOING transfer of securities, there's no indication of cash value
             (
             """
@@ -257,6 +256,8 @@ final class ChuckHistoryActionTests: XCTestCase {
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -200.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
 
+            // income
+            
             (
             """
             "03/01/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
@@ -275,6 +276,14 @@ final class ChuckHistoryActionTests: XCTestCase {
             """,
             ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
             
+            // miscflow
+            
+            (
+            """
+            "03/01/2021","MoneyLink Transfer","","My Bank","","","","-$17.00",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
+
             (
             """
             "03/01/2021","Promotional Award","","PROMOTIONAL AWARD","","","","$100.00",

--- a/Tests/Importers/ChuckHistoryActionTests.swift
+++ b/Tests/Importers/ChuckHistoryActionTests.swift
@@ -197,71 +197,79 @@ final class ChuckHistoryActionTests: XCTestCase {
     }
     
     func testVarious() throws {
+        
+        let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
+        let miscflow = AllocData.MTransaction.Action.miscflow
+        let income = AllocData.MTransaction.Action.income
+        let buysell = AllocData.MTransaction.Action.buysell
+        let transfer = AllocData.MTransaction.Action.transfer
+        let accountID = "XXXX-5678"
+        
         let rows: [(String, AllocRowed.DecodedRow)] = [
             (
             """
-            "09/28/2021","MoneyLink Transfer","","My Bank","","","","-$1000.01",
+            "03/01/2021","MoneyLink Transfer","","My Bank","","","","-$17.00",
             """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
             (
             """
-            "09/27/2021","Sell","VOO","VANGUARD S&P 500","10","$137.1222","$0.04","$1370.12",
+            "03/01/2021","Sell","VOO","VANGUARD S&P 500","10","$17.00","$0.04","$170.12",
             """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": -10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
             (
             """
-            "09/27/2021","Buy","VOO","VANGUARD S&P 500","10","$137.1222","","-$1370.12",
+            "03/01/2021","Buy","VOO","VANGUARD S&P 500","10","$17.0","","-$1370.12",
             """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
+            ( //TODO what should reinvest be?
+            """
+            "03/01/2021","Reinvest Shares","VOO","VANGUARD S&P 500","0.10","$17.00","","-$3.71",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 0.1, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
+            ( //TODO what to do?
+            """
+            "03/01/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]), //, "txnSecurityID": "VOO"
             (
             """
-            "09/27/2021","Reinvest Shares","VOO","VANGUARD S&P 500","0.0334","$110.9322","","-$3.71",
+            "03/01/2021","Cash Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
             """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
+            ( //TODO broken
+            """
+            "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","-50","","","",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -50.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
+            ( //TODO broken
+            """
+            "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","200","","","",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
             (
             """
-            "09/27/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$3.71",
+            "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","$200.00",
             """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""]),
             (
             """
-            "09/27/2021","Cash Dividend","VOO","VANGUARD S&P 500","","","","$300.21",
+            "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","-$200.00",
             """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""]),
             (
             """
-            "09/27/2021","Security Transfer","VOO","VANGUARD S&P 500","-50","","","",
+            "03/01/2021","Promotional Award","","PROMOTIONAL AWARD","","","","$100.00",
             """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
             (
             """
-            "09/27/2021","Security Transfer","VOO","VANGUARD S&P 500","200","","","",
+            "03/01/2021 as of 09/26/2021","Bank Interest","","BANK INT 123456-789123 SCHWAB BANK","","","","$17.00",
             """,
-            [:]),
-            (
-            """
-            "09/27/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","$2000.00",
-            """,
-            [:]),
-            (
-            """
-            "09/27/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","-$2000.00",
-            """,
-            [:]),
-            (
-            """
-            "09/27/2021","Promotional Award","","PROMOTIONAL AWARD","","","","$100.00",
-            """,
-            [:]),
-            (
-            """
-            "09/27/2021 as of 09/26/2021","Bank Interest","","BANK INT 123456-789123 SCHWAB BANK","","","","$1.23",
-            """,
-            [:]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
         ]
         
         let body = """
-        "Transactions  for account XXXX-5678 as of 09/27/2021 22:00:26 ET"
+        "Transactions  for account XXXX-5678 as of 03/01/2021 22:00:26 ET"
         "Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount",
         ##ROW##
         """
@@ -271,19 +279,8 @@ final class ChuckHistoryActionTests: XCTestCase {
             let dataStr = body.replacingOccurrences(of: "##ROW##", with: row.0).data(using: .utf8)!
             let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
 
-//            let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
-//            let expected: [AllocRowed.DecodedRow] = [
-//                [
-//                    "txnAction": MTransaction.Action.miscflow,
-//                    "txnTransactedAt": YYYYMMDDts,
-//                    "txnAccountID": "X0000000A",
-//                    "txnShareCount": -17.0,
-//                    "txnSharePrice": 1.0,
-//                ],
-//            ]
-
-            XCTAssertEqual([row.1], actual)
-            XCTAssertEqual(0, rr.count)
+            XCTAssertEqual([row.1], actual, "ROW: \(row)")
+            XCTAssertEqual(0, rr.count, "ROW: \(row)")
         }
     }
 }

--- a/Tests/Importers/ChuckHistoryActionTests.swift
+++ b/Tests/Importers/ChuckHistoryActionTests.swift
@@ -195,4 +195,95 @@ final class ChuckHistoryActionTests: XCTestCase {
         let expected: [AllocRowed.DecodedRow] = []
         XCTAssertEqual(expected, actual)
     }
+    
+    func testVarious() throws {
+        let rows: [(String, AllocRowed.DecodedRow)] = [
+            (
+            """
+            "09/28/2021","MoneyLink Transfer","","My Bank","","","","-$1000.01",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Sell","VOO","VANGUARD S&P 500","10","$137.1222","$0.04","$1370.12",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Buy","VOO","VANGUARD S&P 500","10","$137.1222","","-$1370.12",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Reinvest Shares","VOO","VANGUARD S&P 500","0.0334","$110.9322","","-$3.71",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$3.71",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Cash Dividend","VOO","VANGUARD S&P 500","","","","$300.21",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Security Transfer","VOO","VANGUARD S&P 500","-50","","","",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Security Transfer","VOO","VANGUARD S&P 500","200","","","",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","$2000.00",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","-$2000.00",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021","Promotional Award","","PROMOTIONAL AWARD","","","","$100.00",
+            """,
+            [:]),
+            (
+            """
+            "09/27/2021 as of 09/26/2021","Bank Interest","","BANK INT 123456-789123 SCHWAB BANK","","","","$1.23",
+            """,
+            [:]),
+        ]
+        
+        let body = """
+        "Transactions  for account XXXX-5678 as of 09/27/2021 22:00:26 ET"
+        "Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount",
+        ##ROW##
+        """
+        
+        for row in rows {
+            var rr = [AllocRowed.RawRow]()
+            let dataStr = body.replacingOccurrences(of: "##ROW##", with: row.0).data(using: .utf8)!
+            let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
+
+//            let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
+//            let expected: [AllocRowed.DecodedRow] = [
+//                [
+//                    "txnAction": MTransaction.Action.miscflow,
+//                    "txnTransactedAt": YYYYMMDDts,
+//                    "txnAccountID": "X0000000A",
+//                    "txnShareCount": -17.0,
+//                    "txnSharePrice": 1.0,
+//                ],
+//            ]
+
+            XCTAssertEqual([row.1], actual)
+            XCTAssertEqual(0, rr.count)
+        }
+    }
 }

--- a/Tests/Importers/ChuckHistoryActionTests.swift
+++ b/Tests/Importers/ChuckHistoryActionTests.swift
@@ -205,79 +205,95 @@ final class ChuckHistoryActionTests: XCTestCase {
         let transfer = AllocData.MTransaction.Action.transfer
         let accountID = "XXXX-5678"
         
-        let rows: [(String, AllocRowed.DecodedRow)] = [
+        let rows: [(csvRow: String, expected: AllocRowed.DecodedRow?, rejectedRows: Int)] = [
 
             (
             """
             "03/01/2021","MoneyLink Transfer","","My Bank","","","","-$17.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
+            0),
 
             (
             """
             "03/01/2021","Sell","VOO","VANGUARD S&P 500","10","$17.00","$0.04","$170.12",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": -10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": -10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"],
+            0),
 
             (
             """
             "03/01/2021","Buy","VOO","VANGUARD S&P 500","10","$17.0","","-$1370.12",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
-
-            (
-            """
-            "03/01/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
-            """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]), //, "txnSecurityID": "VOO"
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"],
+            0),
 
             (
             """
             "03/01/2021","Reinvest Shares","VOO","VANGUARD S&P 500","0.10","$17.00","","-$3.71",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 0.1, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 0.1, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"],
+            0),
 
+            // ignore OUTGOING transfer of securities, because there's no indication of cash value
             (
-            """
-            "03/01/2021","Cash Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
-            """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
-            
-            ( //TODO broken
             """
             "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","-50","","","",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -50.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
+            nil,
+            //["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -50.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]
+            1),
             
-            ( //TODO broken
+            // ignore INCOMING transfer of securities, because there's no indication of cash value
+            (
             """
             "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","200","","","",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
+            nil,
+            //["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"],
+            1),
 
             (
             """
             "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","$200.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""],
+            0),
 
             (
             """
             "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","-$200.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -200.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": ""],
+            0),
 
+            (
+            """
+            "03/01/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"],
+            0),
+
+            (
+            """
+            "03/01/2021","Cash Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
+            """,
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"],
+            0),
+            
             (
             """
             "03/01/2021","Promotional Award","","PROMOTIONAL AWARD","","","","$100.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
+            0),
 
             (
             """
             "03/01/2021 as of 09/26/2021","Bank Interest","","BANK INT 123456-789123 SCHWAB BANK","","","","$17.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
+            0),
         ]
         
         let body = """
@@ -288,11 +304,13 @@ final class ChuckHistoryActionTests: XCTestCase {
         
         for row in rows {
             var rr = [AllocRowed.RawRow]()
-            let dataStr = body.replacingOccurrences(of: "##ROW##", with: row.0).data(using: .utf8)!
+            let dataStr = body.replacingOccurrences(of: "##ROW##", with: row.csvRow).data(using: .utf8)!
             let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
 
-            XCTAssertEqual([row.1], actual, "ROW: \(row)")
-            XCTAssertEqual(0, rr.count, "ROW: \(row)")
+            let expected: [AllocRowed.DecodedRow] = row.expected != nil ? [row.expected!] : []
+            
+            XCTAssertEqual(expected, actual, "ROW: \(row.csvRow)")
+            XCTAssertEqual(row.rejectedRows, rr.count, "ROW: \(row.csvRow)")
         }
     }
 }

--- a/Tests/Importers/ChuckHistoryActionTests.swift
+++ b/Tests/Importers/ChuckHistoryActionTests.swift
@@ -205,100 +205,87 @@ final class ChuckHistoryActionTests: XCTestCase {
         let transfer = AllocData.MTransaction.Action.transfer
         let accountID = "XXXX-5678"
         
-        let rows: [(csvRow: String, expected: AllocRowed.DecodedRow, rejectedRows: Int)] = [
+        let rows: [(csvRow: String, expected: AllocRowed.DecodedRow)] = [
 
             (
             """
             "03/01/2021","MoneyLink Transfer","","My Bank","","","","-$17.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": -17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
 
             (
             """
             "03/01/2021","Sell","VOO","VANGUARD S&P 500","10","$17.00","$0.04","$170.12",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": -10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": -10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
 
             (
             """
             "03/01/2021","Buy","VOO","VANGUARD S&P 500","10","$17.0","","-$1370.12",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 10.0, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
 
             (
             """
             "03/01/2021","Reinvest Shares","VOO","VANGUARD S&P 500","0.10","$17.00","","-$3.71",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 0.1, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": buysell, "txnShareCount": 0.1, "txnAccountID": accountID, "txnSharePrice": 17.0, "txnSecurityID": "VOO"]),
 
             // with OUTGOING transfer of securities, there's no indication of cash value
             (
             """
             "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","-50","","","",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -50.0, "txnAccountID": accountID, "txnSecurityID": "VOO"],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -50.0, "txnAccountID": accountID, "txnSecurityID": "VOO"]),
 
             // with INCOMING transfer of securities, there's no indication of cash value
             (
             """
             "03/01/2021","Security Transfer","VOO","VANGUARD S&P 500","200","","","",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSecurityID": "VOO"],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSecurityID": "VOO"]),
 
             (
             """
             "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","$200.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": 200.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
 
             (
             """
             "03/01/2021","Security Transfer","NO NUMBER","TOA ACAT 0123","","","","-$200.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -200.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": transfer, "txnShareCount": -200.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
 
             (
             """
             "03/01/2021","Reinvest Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
 
             (
             """
             "03/01/2021","Cash Dividend","VOO","VANGUARD S&P 500","","","","$17.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0, "txnSecurityID": "VOO"]),
 
             (
             """
             "03/01/2021 as of 09/26/2021","Bank Interest","","BANK INT 123456-789123 SCHWAB BANK","","","","$17.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": income, "txnShareCount": 17.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
             
             (
             """
             "03/01/2021","Promotional Award","","PROMOTIONAL AWARD","","","","$100.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
 
             (
             """
             "03/01/2021","Random thing that cannot be anticipated","","RANDOM THING","","","","$100.00",
             """,
-            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0],
-            0),
+            ["txnTransactedAt": YYYYMMDDts, "txnAction": miscflow, "txnShareCount": 100.0, "txnAccountID": accountID, "txnSharePrice": 1.0]),
         ]
         
         let body = """
@@ -313,7 +300,7 @@ final class ChuckHistoryActionTests: XCTestCase {
             let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
 
             XCTAssertEqual([row.expected], actual, "ROW: \(row.csvRow)")
-            XCTAssertEqual(row.rejectedRows, rr.count, "ROW: \(row.csvRow)")
+            //XCTAssertEqual(row.rejectedRows, rr.count, "ROW: \(row.csvRow)")
         }
     }
 }

--- a/Tests/Importers/ChuckHistoryTests.swift
+++ b/Tests/Importers/ChuckHistoryTests.swift
@@ -114,9 +114,9 @@ final class ChuckHistoryTests: XCTestCase {
                                                              timeZone: tzNewYork)
         
         let expected: [AllocRowed.DecodedRow] = [
-            ["txnAccountID": "XXXX-1234", "txnShareCount": 100.0, "txnSharePrice": 1.0, "txnTransactedAt": timestamp3, "txnAction": MTransaction.Action.income],
+            ["txnAccountID": "XXXX-1234", "txnShareCount": 100.0, "txnSharePrice": 1.0, "txnTransactedAt": timestamp3, "txnAction": MTransaction.Action.miscflow],
             ["txnAction": MTransaction.Action.buysell, "txnShareCount": 961.0, "txnSharePrice": 105.0736, "txnAccountID": "XXXX-1234", "txnTransactedAt": timestamp1, "txnSecurityID": "SCHB"],
-            ["txnTransactedAt": timestamp4, "txnSharePrice": 1.0, "txnSecurityID": "", "txnAccountID": "XXXX-1234", "txnAction": MTransaction.Action.transfer, "txnShareCount": 101000.0],
+            ["txnTransactedAt": timestamp4, "txnSharePrice": 1.0, "txnAccountID": "XXXX-1234", "txnAction": MTransaction.Action.transfer, "txnShareCount": 101000.0],
             ["txnTransactedAt": timestamp2, "txnAccountID": "XXXX-5678", "txnSecurityID": "VOO", "txnAction": MTransaction.Action.buysell, "txnShareCount": -10.0, "txnSharePrice": 137.1222],
             ["txnAccountID": "XXXX-5678", "txnShareCount": 0.55, "txnSharePrice": 1.0, "txnAction": MTransaction.Action.income, "txnTransactedAt": timestamp4],
 

--- a/Tests/Importers/ChuckHistoryTests.swift
+++ b/Tests/Importers/ChuckHistoryTests.swift
@@ -122,6 +122,14 @@ final class ChuckHistoryTests: XCTestCase {
 
         ]
         XCTAssertEqual(expected, actual)
+        
+        let rejected: [AllocRowed.RawRow] = [
+            ["Action": "", "Quantity": "", "Symbol": "", "Date": "Transactions Total", "Amount": "$524.82", "Price": "", "Fees & Comm": "", "Description": "", "": ""],
+            ["Description": "", "Action": "", "Fees & Comm": "", "Quantity": "", "Date": "Transactions Total", "Price": "", "Amount": "$524.82", "": "", "Symbol": ""]
+        ]
+        XCTAssertEqual(rejected, rr)
+        
+        XCTAssertEqual(2, rr.count)
     }
     
     func testParseAccountTitleID() throws {

--- a/Tests/Importers/ChuckPositionsAllTests.swift
+++ b/Tests/Importers/ChuckPositionsAllTests.swift
@@ -127,6 +127,7 @@ final class ChuckPositionsAllTests: XCTestCase {
         let exportedAt: Date? = actual[0]["exportedAt"] as? Date
         let expectedExportedAt = df.date(from: "2021-09-27T01:59:00+0000")!
         XCTAssertEqual(expectedExportedAt, exportedAt)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testAccountOutput() throws {
@@ -139,6 +140,7 @@ final class ChuckPositionsAllTests: XCTestCase {
             ["accountID": "XXXX-5678", "title": "Roth IRA"],
         ]
         XCTAssertEqual(expected, actual)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testHoldingOutput() throws {
@@ -154,6 +156,7 @@ final class ChuckPositionsAllTests: XCTestCase {
             ["holdingAccountID": "XXXX-5678", "holdingSecurityID": "CORE", "shareBasis": 1.0, "shareCount": 42.82],
         ]
         XCTAssertEqual(expected, actual)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testSecurityOutput() throws {
@@ -168,6 +171,7 @@ final class ChuckPositionsAllTests: XCTestCase {
             ["securityID": "IAU","sharePrice": 111.0, "updatedAt": ts]
         ]
         XCTAssertEqual(expected, actual)
+        XCTAssertEqual(0, rr.count)
     }
             
     func testParseSourceMeta() throws {
@@ -179,12 +183,12 @@ final class ChuckPositionsAllTests: XCTestCase {
         """
         
         let timestamp = Date()
-        var rejectedRows = [AllocRowed.RawRow]()
+        var rr = [AllocRowed.RawRow]()
         let dataStr = str.data(using: .utf8)!
         
         let actual: [MSourceMeta.DecodedRow] = try imp.decode(MSourceMeta.self,
                                                        dataStr,
-                                                       rejectedRows: &rejectedRows,
+                                                       rejectedRows: &rr,
                                                        outputSchema: .allocMetaSource,
                                                        url: URL(string: "http://blah.com"),
                                                        timestamp: timestamp)
@@ -196,6 +200,7 @@ final class ChuckPositionsAllTests: XCTestCase {
         let exportedAt: Date? = actual[0]["exportedAt"] as? Date
         let expectedExportedAt = df.date(from: "2021-09-27T01:59:00+0000")!
         XCTAssertEqual(expectedExportedAt, exportedAt)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testParseAccountTitleID() throws {

--- a/Tests/Importers/ChuckPositionsIndivTests.swift
+++ b/Tests/Importers/ChuckPositionsIndivTests.swift
@@ -107,6 +107,7 @@ final class ChuckPositionsIndivTests: XCTestCase {
         let exportedAt: Date? = actual[0]["exportedAt"] as? Date
         let expectedExportedAt = df.date(from: "2021-09-27T01:59:00+0000")!
         XCTAssertEqual(expectedExportedAt, exportedAt)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testAccountOutput() throws {
@@ -118,6 +119,7 @@ final class ChuckPositionsIndivTests: XCTestCase {
             ["accountID": "XXXX-1234", "title": "Individual"],
         ]
         XCTAssertEqual(expected, actual)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testHoldingOutput() throws {
@@ -130,6 +132,7 @@ final class ChuckPositionsIndivTests: XCTestCase {
             ["holdingAccountID": "XXXX-1234", "holdingSecurityID": "CORE", "shareBasis": 1.0, "shareCount": 42.82],
         ]
         XCTAssertEqual(expected, actual)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testSecurityOutput() throws {
@@ -142,6 +145,7 @@ final class ChuckPositionsIndivTests: XCTestCase {
             ["securityID": "SCHB", "sharePrice": 117.42, "updatedAt": ts],
         ]
         XCTAssertEqual(expected, actual)
+        XCTAssertEqual(0, rr.count)
     }
             
     func testParseSourceMeta() throws {
@@ -153,12 +157,12 @@ final class ChuckPositionsIndivTests: XCTestCase {
         """
         
         let timestamp = Date()
-        var rejectedRows = [AllocRowed.RawRow]()
+        var rr = [AllocRowed.RawRow]()
         let dataStr = str.data(using: .utf8)!
         
         let actual: [MSourceMeta.DecodedRow] = try imp.decode(MSourceMeta.self,
                                                        dataStr,
-                                                       rejectedRows: &rejectedRows,
+                                                       rejectedRows: &rr,
                                                        outputSchema: .allocMetaSource,
                                                        url: URL(string: "http://blah.com"),
                                                        timestamp: timestamp)
@@ -170,6 +174,7 @@ final class ChuckPositionsIndivTests: XCTestCase {
         let exportedAt: Date? = actual[0]["exportedAt"] as? Date
         let expectedExportedAt = df.date(from: "2021-09-27T01:59:00+0000")!
         XCTAssertEqual(expectedExportedAt, exportedAt)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testParseAccountTitleID() throws {

--- a/Tests/Importers/FidoHistoryActionTests.swift
+++ b/Tests/Importers/FidoHistoryActionTests.swift
@@ -154,4 +154,77 @@ final class FidoHistoryActionTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
 
+    
+    func testVarious() throws {
+        
+        let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
+        let miscflow = AllocData.MTransaction.Action.miscflow
+        let income = AllocData.MTransaction.Action.income
+        let buysell = AllocData.MTransaction.Action.buysell
+        let transfer = AllocData.MTransaction.Action.transfer
+        let rows: [(csvRow: String, expected: [AllocRowed.DecodedRow], rejectedRows: Int)] = [
+            ("03/01/2021,CASH MGMT X0000000A, DEBIT CARD PURCHASE, , No Description,Cash,,,,,,-17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+            ("[03/01/2021,CASH MGMT X0000000A, DIRECT DEBIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,-17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+            ("03/01/2021,CASH MGMT X0000000A, DIRECT DEPOSIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+            ("03/01/2021,PASSIVE X0000000A,  REDEMPTION FROM CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), ,  FIDELITY GOVERNMENT MONEY MARKET,Cash,-17.00,1,,,,17.00,",
+             [], 1),  //TODO avoid rejection?
+            ("03/01/2021,PASSIVE X0000000A,  PURCHASE INTO CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,700.00,1,,,,-700.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 700.0, "txnAction": buysell, "txnAccountID": "X0000000A", "txnSecurityID": "SPAXX"]], 0),
+            ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,17.0,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+            ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FTOROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,-17.0,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+            ("03/01/2021,CASH MGMT X0000000A, TRANSFER OF ASSETS ACAT DELIVER (Cash), , No Description,Cash,,,,,,17.0,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": transfer, "txnAccountID": "X0000000A", "txnSecurityID":""]], 0),
+            ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT RECEIVE, TLT, ISHARES TR 20 YR TR BD ETF,Cash,86,144.41,,0.07,,12418.76,08/02/2021",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": 86.0, "txnAction": transfer, "txnAccountID": "X0000000A", "txnSecurityID":"TLT"]], 0),
+            ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT DELIVER, TLT, ISHARES TR 20 YR TR BD ETF,Cash,-86,144.41,,0.07,,12418.76,08/02/2021",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": -86.0, "txnAction": transfer, "txnAccountID": "X0000000A", "txnSecurityID":"TLT"]], 0),
+            ("03/01/2021,PASSIVE X0000000A, DIVIDEND RECEIVED VANGUARD EMERGING MARKETS (VWO) (Cash), VWO,  VANGUARD EMERGING MARKETS,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "VWO"]], 0),
+            ("03/01/2021,PASSIVE X0000000A, LONG-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "BNDX"]], 0),
+            ("03/01/2021,PASSIVE X0000000A, SHORT-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "BNDX"]], 0),
+            ("03/01/2021,CASH MGMT X0000000A, INTEREST EARNED FDIC INSURED DEPOSIT AT JP MORGAN BK NO (QIMHQ) (Cash), QIMHQ, FDIC INSURED DEPOSIT AT JP MORGAN BK NO,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "QIMHQ"]], 0),
+            ("03/01/2021,PASSIVE X0000000A, REINVESTMENT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,0.02,1,,,,-17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A", "txnSecurityID": "SPAXX"]], 0),
+            ("03/01/2021,PASSIVE X0000000A, YOU SOLD VANGUARD IDX FUND (VTI) (Cash), VTI, VANGUARD IDX FUND,Cash,-7.0,100.0,,0.08,700.00,03/05/2021",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": -7.0, "txnAction": buysell, "txnAccountID": "X0000000A", "txnSecurityID": "VTI"]], 0),
+            ("03/01/2021,PASSIVE X0000000A, YOU BOUGHT VANGUARD INDEX FDS VANGUARD VALUE ETF F (VTV) (Cash), VTV, VANGUARD INDEX FDS VANGUARD VALUE ETF F,Cash,7.0,100.0,,,,-700.0,03/05/2021",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": 7.0, "txnAction": buysell, "txnAccountID": "X0000000A", "txnSecurityID": "VTV"]], 0),
+        ]
+        
+        let body = """
+        Brokerage
+
+        Run Date,Account,Action,Symbol,Security Description,Security Type,Quantity,Price ($),Commission ($),Fees ($),Accrued Interest ($),Amount ($),Settlement Date
+        ##ROW##
+         
+        """
+        
+        for row in rows {
+            var rr = [AllocRowed.RawRow]()
+            let dataStr = body.replacingOccurrences(of: "##ROW##", with: row.csvRow).data(using: .utf8)!
+            let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
+
+//            let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
+//            let expected: [AllocRowed.DecodedRow] = [
+//                [
+//                    "txnAction": MTransaction.Action.miscflow,
+//                    "txnTransactedAt": YYYYMMDDts,
+//                    "txnAccountID": "X0000000A",
+//                    "txnShareCount": -17.0,
+//                    "txnSharePrice": 1.0,
+//                ],
+//            ]
+
+            XCTAssertEqual(row.expected, actual)
+            XCTAssertEqual(row.rejectedRows, rr.count)
+        }
+    }
 }

--- a/Tests/Importers/FidoHistoryActionTests.swift
+++ b/Tests/Importers/FidoHistoryActionTests.swift
@@ -73,7 +73,7 @@ final class FidoHistoryActionTests: XCTestCase {
         let actual = imp.decodeDelimitedRows(delimitedRows: delimitedRows,
                                              timeZone: tzNewYork,
                                                   rejectedRows: &rr)
-        let expected: [AllocRowed.DecodedRow] = [["txnSecurityID": "", "txnShareCount": 1010.0, "txnAccountID": "Z00000000", "txnAction": AllocData.MTransaction.Action.transfer, "txnTransactedAt": timestamp1, "txnSharePrice": 1.0]]
+        let expected: [AllocRowed.DecodedRow] = [["txnShareCount": 1010.0, "txnAccountID": "Z00000000", "txnAction": AllocData.MTransaction.Action.transfer, "txnTransactedAt": timestamp1, "txnSharePrice": 1.0]]
         XCTAssertEqual(expected, actual)
     }
 
@@ -164,58 +164,69 @@ final class FidoHistoryActionTests: XCTestCase {
         let transfer = AllocData.MTransaction.Action.transfer
         let accountID = "X0000000A"
         
-        let rows: [(csvRow: String, expected: [AllocRowed.DecodedRow], rejectedRows: Int)] = [
+        let rows: [(csvRow: String, expected: [AllocRowed.DecodedRow])] = [
 
-            ("03/01/2021,CASH MGMT X0000000A, DEBIT CARD PURCHASE, , No Description,Cash,,,,,,-17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
-
-            ("03/01/2021,CASH MGMT X0000000A, DIRECT DEBIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,-17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
-
-            ("03/01/2021,CASH MGMT X0000000A, DIRECT DEPOSIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
-
-            ("03/01/2021,PASSIVE X0000000A,  REDEMPTION FROM CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), ,  FIDELITY GOVERNMENT MONEY MARKET,Cash,-17.00,1,,,,17.00,",
-             [], 1),  //TODO avoid rejection?
-
+            // buysell
+            
             ("03/01/2021,PASSIVE X0000000A,  PURCHASE INTO CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,700.00,1,,,,-700.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 700.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]], 0),
-
-            ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,17.0,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
-
-            ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FTOROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,-17.0,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
-
-            ("03/01/2021,CASH MGMT X0000000A, TRANSFER OF ASSETS ACAT DELIVER (Cash), , No Description,Cash,,,,,,17.0,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":""]], 0),
-
-            ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT RECEIVE, TLT, ISHARES TR 20 YR TR BD ETF,Cash,86,144.41,,0.07,,12418.76,08/02/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": 86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]], 0),
-
-            ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT DELIVER, TLT, ISHARES TR 20 YR TR BD ETF,Cash,-86,144.41,,0.07,,12418.76,08/02/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": -86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]], 0),
-
-            ("03/01/2021,PASSIVE X0000000A, DIVIDEND RECEIVED VANGUARD EMERGING MARKETS (VWO) (Cash), VWO,  VANGUARD EMERGING MARKETS,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "VWO"]], 0),
-
-            ("03/01/2021,PASSIVE X0000000A, LONG-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]], 0),
-
-            ("03/01/2021,PASSIVE X0000000A, SHORT-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]], 0),
-
-            ("03/01/2021,CASH MGMT X0000000A, INTEREST EARNED FDIC INSURED DEPOSIT AT JP MORGAN BK NO (QIMHQ) (Cash), QIMHQ, FDIC INSURED DEPOSIT AT JP MORGAN BK NO,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "QIMHQ"]], 0),
-
-            ("03/01/2021,PASSIVE X0000000A, REINVESTMENT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,0.02,1,,,,-17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 700.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]]),
 
             ("03/01/2021,PASSIVE X0000000A, YOU SOLD VANGUARD IDX FUND (VTI) (Cash), VTI, VANGUARD IDX FUND,Cash,-7.0,100.0,,0.08,700.00,03/05/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": -7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTI"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": -7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTI"]]),
 
             ("03/01/2021,PASSIVE X0000000A, YOU BOUGHT VANGUARD INDEX FDS VANGUARD VALUE ETF F (VTV) (Cash), VTV, VANGUARD INDEX FDS VANGUARD VALUE ETF F,Cash,7.0,100.0,,,,-700.0,03/05/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": 7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTV"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": 7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTV"]]),
+            
+            ("03/01/2021,PASSIVE X0000000A,  REDEMPTION FROM CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,-17.00,1,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]]),
+            
+            ("03/01/2021,PASSIVE X0000000A, REINVESTMENT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,-17.00,1,,,,-17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]]),
+
+            // transfer
+
+            ("03/01/2021,CASH MGMT X0000000A, TRANSFER OF ASSETS ACAT DELIVER (Cash), , No Description,Cash,,,,,,17.0,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": transfer, "txnAccountID": accountID]]),
+
+            ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT RECEIVE, TLT, ISHARES TR 20 YR TR BD ETF,Cash,86,144.41,,0.07,,12418.76,08/02/2021",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": 86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]]),
+
+            ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT DELIVER, TLT, ISHARES TR 20 YR TR BD ETF,Cash,-86,144.41,,0.07,,12418.76,08/02/2021",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": -86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]]),
+
+            // income
+            
+            ("03/01/2021,PASSIVE X0000000A, DIVIDEND RECEIVED VANGUARD EMERGING MARKETS (VWO) (Cash), VWO,  VANGUARD EMERGING MARKETS,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "VWO"]]),
+
+            ("03/01/2021,PASSIVE X0000000A, LONG-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]]),
+
+            ("03/01/2021,PASSIVE X0000000A, SHORT-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]]),
+
+            ("03/01/2021,CASH MGMT X0000000A, INTEREST EARNED FDIC INSURED DEPOSIT AT JP MORGAN BK NO (QIMHQ) (Cash), QIMHQ, FDIC INSURED DEPOSIT AT JP MORGAN BK NO,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "QIMHQ"]]),
+
+            // miscflow
+            
+            ("03/01/2021,PASSIVE X0000000A, UNANTICIPATED ITEM TREATED AS MISC FLOW, BLAH, BLORT,Cash,-17.00,1,,,,-17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID, "txnSecurityID": "BLAH"]]),
+
+            ("03/01/2021,CASH MGMT X0000000A, DEBIT CARD PURCHASE, , No Description,Cash,,,,,,-17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]]),
+
+            ("03/01/2021,CASH MGMT X0000000A, DIRECT DEBIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,-17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]]),
+
+            ("03/01/2021,CASH MGMT X0000000A, DIRECT DEPOSIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,17.00,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]]),
+
+            ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,17.0,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]]),
+
+            ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FTOROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,-17.0,",
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]]),
         ]
         
         let body = """
@@ -232,7 +243,7 @@ final class FidoHistoryActionTests: XCTestCase {
             let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
 
             XCTAssertEqual(row.expected, actual, "ROW: \(row)")
-            XCTAssertEqual(row.rejectedRows, rr.count, "ROW: \(row)")
+            //XCTAssertEqual(row.rejectedRows, rr.count, "ROW: \(row)")
         }
     }
 }

--- a/Tests/Importers/FidoHistoryActionTests.swift
+++ b/Tests/Importers/FidoHistoryActionTests.swift
@@ -165,7 +165,7 @@ final class FidoHistoryActionTests: XCTestCase {
         let rows: [(csvRow: String, expected: [AllocRowed.DecodedRow], rejectedRows: Int)] = [
             ("03/01/2021,CASH MGMT X0000000A, DEBIT CARD PURCHASE, , No Description,Cash,,,,,,-17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
-            ("[03/01/2021,CASH MGMT X0000000A, DIRECT DEBIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,-17.00,",
+            ("03/01/2021,CASH MGMT X0000000A, DIRECT DEBIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,-17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
             ("03/01/2021,CASH MGMT X0000000A, DIRECT DEPOSIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),

--- a/Tests/Importers/FidoHistoryActionTests.swift
+++ b/Tests/Importers/FidoHistoryActionTests.swift
@@ -165,39 +165,55 @@ final class FidoHistoryActionTests: XCTestCase {
         let accountID = "X0000000A"
         
         let rows: [(csvRow: String, expected: [AllocRowed.DecodedRow], rejectedRows: Int)] = [
+
             ("03/01/2021,CASH MGMT X0000000A, DEBIT CARD PURCHASE, , No Description,Cash,,,,,,-17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
+
             ("03/01/2021,CASH MGMT X0000000A, DIRECT DEBIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,-17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
+
             ("03/01/2021,CASH MGMT X0000000A, DIRECT DEPOSIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
+
             ("03/01/2021,PASSIVE X0000000A,  REDEMPTION FROM CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), ,  FIDELITY GOVERNMENT MONEY MARKET,Cash,-17.00,1,,,,17.00,",
              [], 1),  //TODO avoid rejection?
+
             ("03/01/2021,PASSIVE X0000000A,  PURCHASE INTO CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,700.00,1,,,,-700.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 700.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]], 0),
+
             ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,17.0,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
+
             ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FTOROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,-17.0,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
+
             ("03/01/2021,CASH MGMT X0000000A, TRANSFER OF ASSETS ACAT DELIVER (Cash), , No Description,Cash,,,,,,17.0,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":""]], 0),
+
             ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT RECEIVE, TLT, ISHARES TR 20 YR TR BD ETF,Cash,86,144.41,,0.07,,12418.76,08/02/2021",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": 86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]], 0),
+
             ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT DELIVER, TLT, ISHARES TR 20 YR TR BD ETF,Cash,-86,144.41,,0.07,,12418.76,08/02/2021",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": -86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]], 0),
+
             ("03/01/2021,PASSIVE X0000000A, DIVIDEND RECEIVED VANGUARD EMERGING MARKETS (VWO) (Cash), VWO,  VANGUARD EMERGING MARKETS,Cash,,,,,,17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "VWO"]], 0),
+
             ("03/01/2021,PASSIVE X0000000A, LONG-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]], 0),
+
             ("03/01/2021,PASSIVE X0000000A, SHORT-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]], 0),
+
             ("03/01/2021,CASH MGMT X0000000A, INTEREST EARNED FDIC INSURED DEPOSIT AT JP MORGAN BK NO (QIMHQ) (Cash), QIMHQ, FDIC INSURED DEPOSIT AT JP MORGAN BK NO,Cash,,,,,,17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "QIMHQ"]], 0),
-            //TODO how to handle reinvest
+
             ("03/01/2021,PASSIVE X0000000A, REINVESTMENT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,0.02,1,,,,-17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]], 0),
+
             ("03/01/2021,PASSIVE X0000000A, YOU SOLD VANGUARD IDX FUND (VTI) (Cash), VTI, VANGUARD IDX FUND,Cash,-7.0,100.0,,0.08,700.00,03/05/2021",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": -7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTI"]], 0),
+
             ("03/01/2021,PASSIVE X0000000A, YOU BOUGHT VANGUARD INDEX FDS VANGUARD VALUE ETF F (VTV) (Cash), VTV, VANGUARD INDEX FDS VANGUARD VALUE ETF F,Cash,7.0,100.0,,,,-700.0,03/05/2021",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": 7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTV"]], 0),
         ]

--- a/Tests/Importers/FidoHistoryActionTests.swift
+++ b/Tests/Importers/FidoHistoryActionTests.swift
@@ -162,6 +162,7 @@ final class FidoHistoryActionTests: XCTestCase {
         let income = AllocData.MTransaction.Action.income
         let buysell = AllocData.MTransaction.Action.buysell
         let transfer = AllocData.MTransaction.Action.transfer
+        
         let rows: [(csvRow: String, expected: [AllocRowed.DecodedRow], rejectedRows: Int)] = [
             ("03/01/2021,CASH MGMT X0000000A, DEBIT CARD PURCHASE, , No Description,Cash,,,,,,-17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
@@ -191,6 +192,7 @@ final class FidoHistoryActionTests: XCTestCase {
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "BNDX"]], 0),
             ("03/01/2021,CASH MGMT X0000000A, INTEREST EARNED FDIC INSURED DEPOSIT AT JP MORGAN BK NO (QIMHQ) (Cash), QIMHQ, FDIC INSURED DEPOSIT AT JP MORGAN BK NO,Cash,,,,,,17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "QIMHQ"]], 0),
+            //TODO how to handle reinvest
             ("03/01/2021,PASSIVE X0000000A, REINVESTMENT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,0.02,1,,,,-17.00,",
              [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A", "txnSecurityID": "SPAXX"]], 0),
             ("03/01/2021,PASSIVE X0000000A, YOU SOLD VANGUARD IDX FUND (VTI) (Cash), VTI, VANGUARD IDX FUND,Cash,-7.0,100.0,,0.08,700.00,03/05/2021",
@@ -212,19 +214,8 @@ final class FidoHistoryActionTests: XCTestCase {
             let dataStr = body.replacingOccurrences(of: "##ROW##", with: row.csvRow).data(using: .utf8)!
             let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
 
-//            let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
-//            let expected: [AllocRowed.DecodedRow] = [
-//                [
-//                    "txnAction": MTransaction.Action.miscflow,
-//                    "txnTransactedAt": YYYYMMDDts,
-//                    "txnAccountID": "X0000000A",
-//                    "txnShareCount": -17.0,
-//                    "txnSharePrice": 1.0,
-//                ],
-//            ]
-
-            XCTAssertEqual(row.expected, actual)
-            XCTAssertEqual(row.rejectedRows, rr.count)
+            XCTAssertEqual(row.expected, actual, "ROW: \(row)")
+            XCTAssertEqual(row.rejectedRows, rr.count, "ROW: \(row)")
         }
     }
 }

--- a/Tests/Importers/FidoHistoryActionTests.swift
+++ b/Tests/Importers/FidoHistoryActionTests.swift
@@ -162,43 +162,44 @@ final class FidoHistoryActionTests: XCTestCase {
         let income = AllocData.MTransaction.Action.income
         let buysell = AllocData.MTransaction.Action.buysell
         let transfer = AllocData.MTransaction.Action.transfer
+        let accountID = "X0000000A"
         
         let rows: [(csvRow: String, expected: [AllocRowed.DecodedRow], rejectedRows: Int)] = [
             ("03/01/2021,CASH MGMT X0000000A, DEBIT CARD PURCHASE, , No Description,Cash,,,,,,-17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
             ("03/01/2021,CASH MGMT X0000000A, DIRECT DEBIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,-17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
             ("03/01/2021,CASH MGMT X0000000A, DIRECT DEPOSIT XCEL ENERGY 0000001111XCELENERGY (Cash), , No Description,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
             ("03/01/2021,PASSIVE X0000000A,  REDEMPTION FROM CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), ,  FIDELITY GOVERNMENT MONEY MARKET,Cash,-17.00,1,,,,17.00,",
              [], 1),  //TODO avoid rejection?
             ("03/01/2021,PASSIVE X0000000A,  PURCHASE INTO CORE ACCOUNT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) MORNING TRADE (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,700.00,1,,,,-700.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 700.0, "txnAction": buysell, "txnAccountID": "X0000000A", "txnSecurityID": "SPAXX"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 700.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]], 0),
             ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,17.0,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
             ("03/01/2021,CASH MGMT X0000000A, TRANSFERRED FTOROM VS Z00-123456-1 (Cash),  , No Description,Cash,,,,,,-17.0,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID]], 0),
             ("03/01/2021,CASH MGMT X0000000A, TRANSFER OF ASSETS ACAT DELIVER (Cash), , No Description,Cash,,,,,,17.0,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": transfer, "txnAccountID": "X0000000A", "txnSecurityID":""]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":""]], 0),
             ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT RECEIVE, TLT, ISHARES TR 20 YR TR BD ETF,Cash,86,144.41,,0.07,,12418.76,08/02/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": 86.0, "txnAction": transfer, "txnAccountID": "X0000000A", "txnSecurityID":"TLT"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": 86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]], 0),
             ("03/01/2021,BROKERAGE X0000000A, TRANSFER OF ASSETS ACAT DELIVER, TLT, ISHARES TR 20 YR TR BD ETF,Cash,-86,144.41,,0.07,,12418.76,08/02/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": -86.0, "txnAction": transfer, "txnAccountID": "X0000000A", "txnSecurityID":"TLT"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 144.41, "txnShareCount": -86.0, "txnAction": transfer, "txnAccountID": accountID, "txnSecurityID":"TLT"]], 0),
             ("03/01/2021,PASSIVE X0000000A, DIVIDEND RECEIVED VANGUARD EMERGING MARKETS (VWO) (Cash), VWO,  VANGUARD EMERGING MARKETS,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "VWO"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "VWO"]], 0),
             ("03/01/2021,PASSIVE X0000000A, LONG-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "BNDX"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]], 0),
             ("03/01/2021,PASSIVE X0000000A, SHORT-TERM CAP GAIN VANGUARD CHARLOTTE TOTAL INTL BD INDEX (BNDX) (Cash), BNDX, VANGUARD CHARLOTTE TOTAL INTL BD INDEX,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "BNDX"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "BNDX"]], 0),
             ("03/01/2021,CASH MGMT X0000000A, INTEREST EARNED FDIC INSURED DEPOSIT AT JP MORGAN BK NO (QIMHQ) (Cash), QIMHQ, FDIC INSURED DEPOSIT AT JP MORGAN BK NO,Cash,,,,,,17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": "X0000000A", "txnSecurityID": "QIMHQ"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": 17.0, "txnAction": income, "txnAccountID": accountID, "txnSecurityID": "QIMHQ"]], 0),
             //TODO how to handle reinvest
             ("03/01/2021,PASSIVE X0000000A, REINVESTMENT FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash), SPAXX, FIDELITY GOVERNMENT MONEY MARKET,Cash,0.02,1,,,,-17.00,",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": "X0000000A", "txnSecurityID": "SPAXX"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 1.0, "txnShareCount": -17.0, "txnAction": miscflow, "txnAccountID": accountID, "txnSecurityID": "SPAXX"]], 0),
             ("03/01/2021,PASSIVE X0000000A, YOU SOLD VANGUARD IDX FUND (VTI) (Cash), VTI, VANGUARD IDX FUND,Cash,-7.0,100.0,,0.08,700.00,03/05/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": -7.0, "txnAction": buysell, "txnAccountID": "X0000000A", "txnSecurityID": "VTI"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": -7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTI"]], 0),
             ("03/01/2021,PASSIVE X0000000A, YOU BOUGHT VANGUARD INDEX FDS VANGUARD VALUE ETF F (VTV) (Cash), VTV, VANGUARD INDEX FDS VANGUARD VALUE ETF F,Cash,7.0,100.0,,,,-700.0,03/05/2021",
-             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": 7.0, "txnAction": buysell, "txnAccountID": "X0000000A", "txnSecurityID": "VTV"]], 0),
+             [["txnTransactedAt": YYYYMMDDts, "txnSharePrice": 100.0, "txnShareCount": 7.0, "txnAction": buysell, "txnAccountID": accountID, "txnSecurityID": "VTV"]], 0),
         ]
         
         let body = """

--- a/Tests/Importers/FidoHistoryTests.swift
+++ b/Tests/Importers/FidoHistoryTests.swift
@@ -101,9 +101,9 @@ final class FidoHistoryTests: XCTestCase {
         XXX
         """
 
-        var rejectedRows = [AllocRowed.RawRow]()
+        var rr = [AllocRowed.RawRow]()
         let dataStr = str.data(using: .utf8)!
-        let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rejectedRows, timeZone: tzNewYork)
+        let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
 
         let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
         let expected: AllocRowed.DecodedRow = [
@@ -116,7 +116,7 @@ final class FidoHistoryTests: XCTestCase {
         ]
 
         XCTAssertTrue(areEqual(expected, actual.first!))
-        XCTAssertEqual(0, rejectedRows.count)
+        XCTAssertEqual(0, rr.count)
     }
     
     func testMiscFlow() throws {
@@ -131,9 +131,9 @@ final class FidoHistoryTests: XCTestCase {
         XXX
         """
 
-        var rejectedRows = [AllocRowed.RawRow]()
+        var rr = [AllocRowed.RawRow]()
         let dataStr = str.data(using: .utf8)!
-        let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rejectedRows, timeZone: tzNewYork)
+        let actual: [AllocRowed.DecodedRow] = try imp.decode(MTransaction.self, dataStr, rejectedRows: &rr, timeZone: tzNewYork)
 
         let YYYYMMDDts = parseFidoMMDDYYYY("03/01/2021", timeZone: tzNewYork)!
         let expected: [AllocRowed.DecodedRow] = [
@@ -161,6 +161,6 @@ final class FidoHistoryTests: XCTestCase {
         ]
 
         XCTAssertEqual(expected, actual)
-        XCTAssertEqual(0, rejectedRows.count)
+        XCTAssertEqual(0, rr.count)
     }
 }


### PR DESCRIPTION
This mostly affects the history importers (for Chuck and Fido).

Ignore "total" rows.

More consistent handling of action types, such as for transfers.

More comprehensive tests.